### PR TITLE
Make software BP work with ATMEL ICE

### DIFF
--- a/src/jtag3run.cc
+++ b/src/jtag3run.cc
@@ -200,7 +200,7 @@ void jtag3::expectEvent(bool &breakpoint, bool &gdbInterrupt)
       // The bits do not fully match that description but to
       // a good degree.
       case (SCOPE_AVR << 8) | EVT3_BREAK:
-          if ((!is_xmega && evtbuf[7] != 0) ||
+          if ((!is_xmega && (evtbuf[6] != 0 || evtbuf[7] != 0)) ||
               (is_xmega && evtbuf[7] != 0x40))
           {
               // program breakpoint


### PR DESCRIPTION
Using an ATMEL ICE, I was able to set software breakpoints on an
atmega328p, the mcu would properly break but avarice would display
"ignoring break event" and I would then have to manually interrupt from
avr-gdb.

Running in debug mode, I noticed that the particular payload differed
slightly from what avarice is currently expecting. For example:

```
command "set BP" [0x12, 0x43]
0E 00 16 00 12 43 00 9E 00 00 00
Received 0x81 0x11 0x00 0x06 0x0e 0x16
read:  0e 16 00 12 80 00

Got message seqno 22 (command_sequence == 22)
response: 12 80 00

command "go" [0x12, 0x32]
0E 00 17 00 12 32 00
Received 0x81 0x11 0x00 0x06 0x0e 0x17
read:  0e 17 00 12 80 00

Got message seqno 23 (command_sequence == 23)
response: 12 80 00
Waiting for input.
read:  0e 00 7d 00 12 40 4f 00 00 00 01 00 00 85
Event serial 0x007d
ignoring break event
```

The breakpoint is set at 0000009E, so we're expecting to see a 0000004F
in the breakpoint event, which we do. If we look at the last message,
the relevant part of the payload is:
```
12                   AVR_ISP
40                   EVT3_BREAK
4f 00 00 00          b4 encoding for 0000004F
01 00 00 85
```

The code postulates that bytes 6 and 7 are the break status register,
I'm going to makes a wild guess that in the case of this particular
programmer byte 6 might be the low byte and byte 7 the high byte (b2
encoding), which is consistent with a software break.