### PR TITLE
clear offset when crossing flash pages

### DIFF
--- a/src/jtag2rw.cc
+++ b/src/jtag2rw.cc
@@ -193,6 +193,7 @@ uchar *jtag2::jtagRead(unsigned long addr, unsigned int numBytes)
 
 	    numBytes -= chunksize;
 	    targetOffset += chunksize;
+	    offset = 0;
 
 	    chunksize = numBytes > pageSize? pageSize: numBytes;
 	    pageAddr += pageSize;

--- a/src/jtag3rw.cc
+++ b/src/jtag3rw.cc
@@ -192,6 +192,7 @@ uchar *jtag3::jtagRead(unsigned long addr, unsigned int numBytes)
 
 	    numBytes -= chunksize;
 	    targetOffset += chunksize;
+	    offset = 0;
 
 	    chunksize = numBytes > pageSize? pageSize: numBytes;
 	    pageAddr += pageSize;


### PR DESCRIPTION
When doing a flash read that crosses pages, clear the offset once the first page is read. Otherwise, GDB will receive incorrect bytes, and the read can overrun the page cache buffer.

Fixes #106.