### PR TITLE
line-buffer stdout to be nice to debug engines

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -583,6 +583,9 @@ int main(int argc, char **argv)
     if (debugMode)
       setvbuf(stderr, NULL, _IOLBF, 0);
 
+    // Be nicer to debug engines running us through pipes
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     int rv = 0;			// return value from main()
 
     try {


### PR DESCRIPTION
Some IDE debug engines start up debug servers in pipes and look for
status messages to indicate the debug server is finished starting
up. The startup messages could be stuck in the stdio buffer,
causing the debug engine to time out.