### PR TITLE
Build Binaries in CI for Windows, Linux and Mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           mkdir avarice_installed
           make install DESTDIR=$(pwd)/avarice_installed/
           file avarice_installed/usr/local/bin/*
-          ldd avarice_installed/usr/local/bin/*
+          ldd avarice_installed/usr/local/bin/avarice
           avarice_installed/usr/local --known-devices || true
       - name: Tar files
         run: tar -cvf avarice.tar.gz -C avarice_installed/usr/local/bin .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           cp /usr/bin/msys-hidapi-0.dll avarice_installed/usr/bin/.
       - name: Run AVaRICE
         run: |
-          avarice_installed/usr/bin/avarice --version || true
+          avarice_installed/usr/bin/avarice --version
           avarice_installed/usr/bin/avarice --known-devices || true
       - uses: actions/upload-artifact@v3
         with:
@@ -79,7 +79,7 @@ jobs:
       - name: Run AVaRICE
         run: |
           avarice_installed/usr/local/bin/avarice --version
-          avarice_installed/usr/local/bin/avarice --known-devices
+          avarice_installed/usr/local/bin/avarice --known-devices || true
       - name: Tar files
         run: tar -cvf avarice.tar.gz -C avarice_installed/usr/local/bin .
       - uses: actions/upload-artifact@v3
@@ -105,7 +105,7 @@ jobs:
       - name: Run AVaRICE
         run: |
           avarice_installed/usr/local/bin/avarice --version
-          avarice_installed/usr/local/bin/avarice --known-devices
+          avarice_installed/usr/local/bin/avarice --known-devices || true
       - name: Tar files
         run: tar -cvf avarice.tar.gz -C avarice_installed .
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Dependencies
         run: | 
-          brew install gcc autoconf automake mk-configure libusb libusb-compat hidapi
+          brew install gcc binutils autoconf automake mk-configure libusb libusb-compat hidapi
       - name: Build AVaRICE
         run: |
           ./Bootstrap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependenncies
-        run: sudo apt-get install -y build-essential make autotools-dev automake binutils-dev
+        run: sudo apt-get install -y build-essential make autotools-dev automake binutils-dev libusb-dev libhidapi-dev
       - name: CI-Build
         run: |
           ./Bootstrap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           ./Bootstrap
           ./configure
-          make -j4
+          make -j$NUMBER_OF_PROCESSORS
           make install DESTDIR=$(pwd)/avarice_installed/
           ls -R avarice_installed
           file avarice_installed/usr/bin/*
@@ -71,7 +71,7 @@ jobs:
         run: |
           ./Bootstrap
           ./configure --enable-target-programming
-          make -j4
+          make -j$NUMBER_OF_PROCESSORS
           mkdir avarice_installed
           make install DESTDIR=$(pwd)/avarice_installed/
           file avarice_installed/usr/local/bin/*
@@ -97,7 +97,7 @@ jobs:
         run: |
           ./Bootstrap
           ./configure
-          make -j4
+          make -j3
           mkdir avarice_installed
           make install DESTDIR=$(pwd)/avarice_installed/
           ls -R avarice_installed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,10 +49,11 @@ jobs:
           ldd avarice_installed/usr/bin/avarice
           cp /mingw64/bin/libusb-1.0.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-2.0.dll avarice_installed/usr/bin/.
-          cp /usr/bin/msys-stdc++-cd /6.dll avarice_installed/usr/bin/.
+          cp /usr/bin/msys-stdc++-6.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-gcc_s-seh-1.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-usb-0-1-4.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-hidapi-0.dll avarice_installed/usr/bin/.
+          avarice_installed/usr/bin/avarice --version || true
           avarice_installed/usr/bin/avarice --known-devices || true
       - uses: actions/upload-artifact@v3
         with:
@@ -73,6 +74,7 @@ jobs:
           make install DESTDIR=$(pwd)/avarice_installed/
           file avarice_installed/usr/local/bin/*
           ldd avarice_installed/usr/local/bin/avarice
+          avarice_installed/usr/bin/avarice --version || true
           avarice_installed/usr/local/bin/avarice --known-devices || true
       - name: Tar files
         run: tar -cvf avarice.tar.gz -C avarice_installed/usr/local/bin .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,32 @@ name: Build Binaries
 on: [push, pull_request]
 
 jobs:
+  build-win64:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          update: false
+          install: git make libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-win32 mingw-w64-x86_64-hidapi
+      - name: CI-Build
+        run: |
+          ./Bootstrap
+          ./configure
+          make -j4
+          make install DESTDIR=$(pwd)/avarice_installed/
+          file avarice_installed/usr/local/bin/*
+          ldd avarice_installed/usr/local/bin/avarice
+          cp /mingw64/bin/libusb-1.0.dll avarice_installed/usr/local/bin/.
+          avarice_installed/usr/local --known-devices || true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Windows 64-bit
+          path: avarice_installed
   build-lin64:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
-        run: sudo sudo apt-get update && apt-get install -y build-essential make autotools-dev automake binutils-dev libusb-dev libhidapi-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential make autotools-dev automake binutils-dev libusb-dev libhidapi-dev
       - name: Build AVaRICE
         run: |
           ./Bootstrap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           msystem: MSYS
           update: false
-          install: git make libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-win32 mingw-w64-x86_64-hidapi
+          install: git make gcc libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-win32 mingw-w64-x86_64-hidapi
       - name: CI-Build
         run: |
           ./Bootstrap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           avarice_installed/usr/bin/avarice --known-devices || true
       - uses: actions/upload-artifact@v3
         with:
-          name: Windows 64-bit
+          name: AVaRICE Windows 64-bit
           path: avarice_installed
   build-lin64:
     runs-on: ubuntu-latest
@@ -80,7 +80,7 @@ jobs:
         run: tar -cvf avarice.tar.gz -C avarice_installed/usr/local/bin .
       - uses: actions/upload-artifact@v3
         with:
-          name: Linux 64-bit
+          name: AVaRICE Linux 64-bit
           path: avarice.tar.gz
   build-darwin-x64:
     runs-on: macos-latest
@@ -92,14 +92,14 @@ jobs:
       - name: Build AVaRICE
         run: |
           ./Bootstrap
-          ./configure --enable-target-programming
+          ./configure
           make -j4
           mkdir avarice_installed
           make install DESTDIR=$(pwd)/avarice_installed/
           ls -R avarice_installed
       - name: Tar files
-        run: tar -cvf simavr.tar.gz -C simavr_installed .
+        run: tar -cvf avarice.tar.gz -C avarice_installed .
       - uses: actions/upload-artifact@v3
         with:
-          name: Mac OS Intel 64-bit
-          path: simavr.tar.gz
+          name: AVaRICE Mac OS Intel 64-bit
+          path: avarice.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,33 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MSYS
           update: false
-          install: git make gcc libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-win32 mingw-w64-x86_64-hidapi
+          install: git make gcc libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils
+      - name: Install libusb-compat-0.1
+        run: |
+          wget https://github.com/Florin-Popescu/libusb-compat-0.1/releases/download/v0.1.7/libusb-compat-0.1_msys_x86_64.zip -O libusb-compat-0.1_msys_x86_64.zip
+          unzip -o libusb-compat-0.1_msys_x86_64.zip
+          cp -r libusb-compat-0.1_msys2_x86_64/* /
+      - name: Build libusb
+        run: |
+          git clone https://github.com/libusb/libusb.git
+          cd ./libusb
+          ./bootstrap.sh
+          ./configure
+          make -j$NUMBER_OF_PROCESSORS
+          make install
+      - name: Build hidapi
+        run: |
+          git clone https://github.com/libusb/hidapi.git
+          cd ./hidapi
+          ./bootstrap
+          ./configure
+          make all -j$NUMBER_OF_PROCESSORS
+          make install
       - name: CI-Build
         run: |
           ./Bootstrap
@@ -24,7 +45,10 @@ jobs:
           file avarice_installed/usr/bin/*
           ldd avarice_installed/usr/bin/avarice
           cp /mingw64/bin/libusb-1.0.dll avarice_installed/usr/bin/.
-          avarice_installed/usr/local --known-devices || true
+          cp /usr/bin/msys-2.0.dll avarice_installed/usr/bin/.
+          cp /usr/bin/msys-stdc++-6.dll avarice_installed/usr/bin/.         
+          cp /usr/bin/msys-gcc_s-seh-1.dll avarice_installed/usr/bin/.         
+          avarice_installed/usr/bin/avarice --known-devices || true
       - uses: actions/upload-artifact@v3
         with:
           name: Windows 64-bit
@@ -32,7 +56,7 @@ jobs:
   build-lin64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Dependenncies
         run: sudo apt-get install -y build-essential make autotools-dev automake binutils-dev libusb-dev libhidapi-dev
       - name: CI-Build
@@ -44,7 +68,7 @@ jobs:
           make install DESTDIR=$(pwd)/avarice_installed/
           file avarice_installed/usr/local/bin/*
           ldd avarice_installed/usr/local/bin/avarice
-          avarice_installed/usr/local --known-devices || true
+          avarice_installed/usr/local/bin/avarice --known-devices || true
       - name: Tar files
         run: tar -cvf avarice.tar.gz -C avarice_installed/usr/local/bin .
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,3 +82,24 @@ jobs:
         with:
           name: Linux 64-bit
           path: avarice.tar.gz
+  build-darwin-x64:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: | 
+          brew install gcc make autoconf automake mk-configure binutils libusb libusb-compat hidapi  
+      - name: Build AVaRICE
+        run: |
+          ./Bootstrap
+          ./configure --enable-target-programming
+          make -j4
+          mkdir avarice_installed
+          make install DESTDIR=$(pwd)/avarice_installed/
+          ls -R avarice_installed
+      - name: Tar files
+        run: tar -cvf simavr.tar.gz -C simavr_installed .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Mac OS Intel 64-bit
+          path: simavr.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,18 @@ jobs:
           msystem: MSYS
           update: false
           install: git make unzip gcc libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils
-      - name: Build libusb-compat-0.1
-        run: |
-          git clone https://github.com/libusb/libusb-compat-0.1.git
-          cd ./libusb-compat-0.1
-          ./bootstrap.sh
-          ./configure
-          make -j$NUMBER_OF_PROCESSORS
-          make install
       - name: Build libusb
         run: |
           git clone https://github.com/libusb/libusb.git
           cd ./libusb
+          ./bootstrap.sh
+          ./configure
+          make -j$NUMBER_OF_PROCESSORS
+          make install
+      - name: Build libusb-compat-0.1
+        run: |
+          git clone https://github.com/libusb/libusb-compat-0.1.git
+          cd ./libusb-compat-0.1
           ./bootstrap.sh
           ./configure
           make -j$NUMBER_OF_PROCESSORS
@@ -49,8 +49,9 @@ jobs:
           ldd avarice_installed/usr/bin/avarice
           cp /mingw64/bin/libusb-1.0.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-2.0.dll avarice_installed/usr/bin/.
-          cp /usr/bin/msys-stdc++-6.dll avarice_installed/usr/bin/.         
-          cp /usr/bin/msys-gcc_s-seh-1.dll avarice_installed/usr/bin/.         
+          cp /usr/bin/msys-stdc++-6.dll avarice_installed/usr/bin/.
+          cp /usr/bin/msys-gcc_s-seh-1.dll avarice_installed/usr/bin/.
+          cp /usr/bin/msys-usb-0-1-4.dll avarice_installed/usr/bin/.
           avarice_installed/usr/bin/avarice --known-devices || true
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,8 @@ jobs:
           cp /usr/bin/msys-gcc_s-seh-1.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-usb-0-1-4.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-hidapi-0.dll avarice_installed/usr/bin/.
+      - name: Run AVaRICE
+        run: |
           avarice_installed/usr/bin/avarice --version || true
           avarice_installed/usr/bin/avarice --known-devices || true
       - uses: actions/upload-artifact@v3
@@ -74,8 +76,10 @@ jobs:
           make install DESTDIR=$(pwd)/avarice_installed/
           file avarice_installed/usr/local/bin/*
           ldd avarice_installed/usr/local/bin/avarice
-          avarice_installed/usr/local/bin/avarice --version || true
-          avarice_installed/usr/local/bin/avarice --known-devices || true
+      - name: Run AVaRICE
+        run: |
+          avarice_installed/usr/local/bin/avarice --version
+          avarice_installed/usr/local/bin/avarice --known-devices
       - name: Tar files
         run: tar -cvf avarice.tar.gz -C avarice_installed/usr/local/bin .
       - uses: actions/upload-artifact@v3
@@ -88,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Dependencies
         run: | 
-          brew install gcc make autoconf automake mk-configure binutils libusb libusb-compat hidapi  
+          brew install gcc autoconf automake mk-configure libusb libusb-compat hidapi
       - name: Build AVaRICE
         run: |
           ./Bootstrap
@@ -97,6 +101,11 @@ jobs:
           mkdir avarice_installed
           make install DESTDIR=$(pwd)/avarice_installed/
           ls -R avarice_installed
+          ldd avarice_installed/usr/local/bin/avarice
+      - name: Run AVaRICE
+        run: |
+          avarice_installed/usr/local/bin/avarice --version
+          avarice_installed/usr/local/bin/avarice --known-devices
       - name: Tar files
         run: tar -cvf avarice.tar.gz -C avarice_installed .
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           avarice_installed/usr/local/bin/avarice --version
           avarice_installed/usr/local/bin/avarice --known-devices || true
       - name: Tar files
-        run: tar -cvf avarice.tar.gz -C avarice_installed/usr/local/bin .
+        run: tar -cvf avarice.tar.gz -C avarice_installed .
       - uses: actions/upload-artifact@v3
         with:
           name: AVaRICE Linux 64-bit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           make install DESTDIR=$(pwd)/avarice_installed/
           file avarice_installed/usr/local/bin/*
           ldd avarice_installed/usr/local/bin/avarice
-          avarice_installed/usr/bin/avarice --version || true
+          avarice_installed/usr/local/bin/avarice --version || true
           avarice_installed/usr/local/bin/avarice --known-devices || true
       - name: Tar files
         run: tar -cvf avarice.tar.gz -C avarice_installed/usr/local/bin .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build Binaries
+on: [push, pull_request]
+
+jobs:
+  build-lin64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependenncies
+        run: sudo apt-get install -y build-essential make autotools-dev automake binutils-dev
+      - name: CI-Build
+        run: |
+          ./Bootstrap
+          ./configure --enable-target-programming
+          make -j4
+          mkdir avarice_installed
+          make install DESTDIR=$(pwd)/avarice_installed/
+          file avarice_installed/usr/local/bin/*
+          ldd avarice_installed/usr/local/bin/*
+          avarice_installed/usr/local --known-devices || true
+      - name: Tar files
+        run: tar -cvf avarice.tar.gz -C avarice_installed/usr/local/bin .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Linux 64-bit
+          path: avarice.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,10 @@ jobs:
           ./configure
           make -j4
           make install DESTDIR=$(pwd)/avarice_installed/
-          file avarice_installed/usr/local/bin/*
-          ldd avarice_installed/usr/local/bin/avarice
-          cp /mingw64/bin/libusb-1.0.dll avarice_installed/usr/local/bin/.
+          ls -R avarice_installed
+          file avarice_installed/usr/bin/*
+          ldd avarice_installed/usr/bin/avarice
+          cp /mingw64/bin/libusb-1.0.dll avarice_installed/usr/bin/.
           avarice_installed/usr/local --known-devices || true
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
-        run: sudo apt-get install -y build-essential make autotools-dev automake binutils-dev libusb-dev libhidapi-dev
+        run: sudo sudo apt-get update && apt-get install -y build-essential make autotools-dev automake binutils-dev libusb-dev libhidapi-dev
       - name: Build AVaRICE
         run: |
           ./Bootstrap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,15 @@ jobs:
         with:
           msystem: MSYS
           update: false
-          install: git make gcc libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils
-      - name: Install libusb-compat-0.1
+          install: git make unzip gcc libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils
+      - name: Build libusb-compat-0.1
         run: |
-          wget https://github.com/Florin-Popescu/libusb-compat-0.1/releases/download/v0.1.7/libusb-compat-0.1_msys_x86_64.zip -O libusb-compat-0.1_msys_x86_64.zip
-          unzip -o libusb-compat-0.1_msys_x86_64.zip
-          cp -r libusb-compat-0.1_msys2_x86_64/* /
+          git clone https://github.com/libusb/libusb-compat-0.1.git
+          cd ./libusb-compat-0.1
+          ./bootstrap.sh
+          ./configure
+          make -j$NUMBER_OF_PROCESSORS
+          make install
       - name: Build libusb
         run: |
           git clone https://github.com/libusb/libusb.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           mkdir avarice_installed
           make install DESTDIR=$(pwd)/avarice_installed/
           ls -R avarice_installed
-          ldd avarice_installed/usr/local/bin/avarice
+          otool -L avarice_installed/usr/local/bin/avarice
       - name: Run AVaRICE
         run: |
           avarice_installed/usr/local/bin/avarice --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           msystem: MSYS
           update: false
-          install: git make unzip gcc libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils
+          install: git make unzip gcc libtool msys/autotools msys/autoconf-wrapper automake cmake msys/binutils mingw-w64-x86_64-libusb
       - name: Build libusb
         run: |
           git clone https://github.com/libusb/libusb.git
@@ -38,7 +38,7 @@ jobs:
           ./configure
           make all -j$NUMBER_OF_PROCESSORS
           make install
-      - name: CI-Build
+      - name: Build AVaRICE
         run: |
           ./Bootstrap
           ./configure
@@ -49,9 +49,10 @@ jobs:
           ldd avarice_installed/usr/bin/avarice
           cp /mingw64/bin/libusb-1.0.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-2.0.dll avarice_installed/usr/bin/.
-          cp /usr/bin/msys-stdc++-6.dll avarice_installed/usr/bin/.
+          cp /usr/bin/msys-stdc++-cd /6.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-gcc_s-seh-1.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-usb-0-1-4.dll avarice_installed/usr/bin/.
+          cp /usr/bin/msys-hidapi-0.dll avarice_installed/usr/bin/.
           avarice_installed/usr/bin/avarice --known-devices || true
       - uses: actions/upload-artifact@v3
         with:
@@ -61,9 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Dependenncies
+      - name: Install Dependencies
         run: sudo apt-get install -y build-essential make autotools-dev automake binutils-dev libusb-dev libhidapi-dev
-      - name: CI-Build
+      - name: Build AVaRICE
         run: |
           ./Bootstrap
           ./configure --enable-target-programming


### PR DESCRIPTION
Enables Github Actions (free for public repos) to build AVaRICE for Windows, Linux and Mac. See [example run](https://github.com/maxgerhardt/avarice/actions/runs/3920535095).

For Windows, uses the MSYS2/MSYS system to build it, as I failed to compile it using native MinGW thanks to missing termios.h and libusb issues.

For Linux, builds on Ubuntu.

For Mac, builds on macOS Monterey 12 ([source](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners)).

Uploads and archives the resulting binaries. Github Actions will always keep the last archives forever, older ones are only kept for 90 days.

Eventually this could be used to do Github releases with source + binaries, which is especially useful for Windows.

Binary runs successfully on Windows with all needed .dll's prepackaged

![grafik](https://user-images.githubusercontent.com/26485477/212499843-2fee7e6f-4d8d-4200-9780-d67585363eb5.png)

