### PR TITLE
Improved workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           file avarice_installed/usr/bin/*
           ldd avarice_installed/usr/bin/avarice
           cp /mingw64/bin/libusb-1.0.dll avarice_installed/usr/bin/.
+          cp /mingw64/bin/libusb-1.0.dll avarice_installed/usr/bin/msys-usb-1.0.dll
           cp /usr/bin/msys-2.0.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-stdc++-6.dll avarice_installed/usr/bin/.
           cp /usr/bin/msys-gcc_s-seh-1.dll avarice_installed/usr/bin/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         run: tar -cvf avarice.tar.gz -C avarice_installed .
       - uses: actions/upload-artifact@v4
         with:
-          name: AVaRICE Linux 64-bit
+          name: AVaRICE Linux Intel 64-bit
           path: avarice.tar.gz
   build-linux-arm64:
     runs-on: ubuntu-24.04-arm
@@ -109,7 +109,7 @@ jobs:
         run: tar -cvf avarice.tar.gz -C avarice_installed .
       - uses: actions/upload-artifact@v4
         with:
-          name: AVaRICE Linux 64-bit
+          name: AVaRICE Linux ARM 64-bit
           path: avarice.tar.gz
   build-darwin-arm64:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build Binaries
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-win64:
@@ -61,8 +61,33 @@ jobs:
         with:
           name: AVaRICE Windows 64-bit
           path: avarice_installed
-  build-lin64:
+  build-linux-intel64:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential make autotools-dev automake binutils-dev libusb-dev libhidapi-dev
+      - name: Build AVaRICE
+        run: |
+          ./Bootstrap
+          ./configure --enable-target-programming
+          make -j$NUMBER_OF_PROCESSORS
+          mkdir avarice_installed
+          make install DESTDIR=$(pwd)/avarice_installed/
+          file avarice_installed/usr/local/bin/*
+          ldd avarice_installed/usr/local/bin/avarice
+      - name: Run AVaRICE
+        run: |
+          avarice_installed/usr/local/bin/avarice --version
+          avarice_installed/usr/local/bin/avarice --known-devices || true
+      - name: Tar files
+        run: tar -cvf avarice.tar.gz -C avarice_installed .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: AVaRICE Linux 64-bit
+          path: avarice.tar.gz
+  build-linux-arm64:
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies
@@ -92,15 +117,28 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Dependencies
         run: | 
-          brew install gcc binutils autoconf automake mk-configure libusb libusb-compat hidapi
+          brew install binutils autoconf automake mk-configure libusb-compat hidapi
       - name: Build AVaRICE
         run: |
           ./Bootstrap
+          # note: we use a constant hidapi include path instead of "pkg-config --cflags hidapi" because that path include  "/hidapi" at the end
+          # through which in turn "hidapi/hidapi.h" will not be found (it would have to be just "hidapi.h").
+          # Actually, we now remove the trailing hidapi in order to account for version changes
+          INC=$(pkg-config --cflags hidapi)
+          INC=${INC%"hidapi"}
+          export CFLAGS="$(pkg-config --cflags libusb) $(pkg-config --cflags libusb-1.0) $INC"
+          export CXXFLAGS="$(pkg-config --cflags libusb) $(pkg-config --cflags libusb-1.0) $INC"
+          export LDFLAGS="$(pkg-config --libs-only-L libusb) $(pkg-config --libs-only-L libusb-1.0) $(pkg-config --libs-only-L hidapi)"
           ./configure
-          make -j3
+          make -j$NUMBER_OF_PROCESSORS
           mkdir avarice_installed
           make install DESTDIR=$(pwd)/avarice_installed/
           ls -R avarice_installed
+          otool -L avarice_installed/usr/local/bin/avarice
+          install_name_tool -change /opt/homebrew/opt/hidapi/lib/libhidapi.0.dylib @executable_path/./libhidapi.0.dylib ./avarice_installed/usr/local/bin/avarice
+          install_name_tool -change /opt/homebrew/opt/libusb-compat/lib/libusb-0.1.4.dylib @executable_path/./libusb-0.1.4.dylib ./avarice_installed/usr/local/bin/avarice
+          cp /opt/homebrew/opt/hidapi/lib/libhidapi.0.dylib ./avarice_installed/usr/local/bin/.
+          cp /opt/homebrew/opt/libusb-compat/lib/libusb-0.1.4.dylib ./avarice_installed/usr/local/bin/.
           otool -L avarice_installed/usr/local/bin/avarice
       - name: Run AVaRICE
         run: |
@@ -111,4 +149,43 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: AVaRICE Mac OS ARM 64-bit
+          path: avarice.tar.gz
+  build-darwin-intel64:
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: | 
+          brew install binutils autoconf automake mk-configure libusb-compat hidapi
+      - name: Build AVaRICE
+        run: |
+          ./Bootstrap
+          # note: we use a constant hidapi include path instead of "pkg-config --cflags hidapi" because that path include  "/hidapi" at the end
+          # through which in turn "hidapi/hidapi.h" will not be found (it would have to be just "hidapi.h").
+          # Actually, we now remove the trailing hidapi in order to account for version changes
+          INC=$(pkg-config --cflags hidapi)
+          INC=${INC%"hidapi"}
+          export CFLAGS="$(pkg-config --cflags libusb) $(pkg-config --cflags libusb-1.0) $INC"
+          export CXXFLAGS="$(pkg-config --cflags libusb) $(pkg-config --cflags libusb-1.0) $INC"
+          export LDFLAGS="$(pkg-config --libs-only-L libusb) $(pkg-config --libs-only-L libusb-1.0) $(pkg-config --libs-only-L hidapi)"
+          ./configure
+          make -j$NUMBER_OF_PROCESSORS
+          mkdir avarice_installed
+          make install DESTDIR=$(pwd)/avarice_installed/
+          ls -R avarice_installed
+          otool -L avarice_installed/usr/local/bin/avarice
+          install_name_tool -change /usr/local/opt/hidapi/lib/libhidapi.0.dylib @executable_path/./libhidapi.0.dylib ./avarice_installed/usr/local/bin/avarice
+          install_name_tool -change /usr/local/opt/libusb-compat/lib/libusb-0.1.4.dylib @executable_path/./libusb-0.1.4.dylib ./avarice_installed/usr/local/bin/avarice
+          cp /usr/local/opt/hidapi/lib/libhidapi.0.dylib ./avarice_installed/usr/local/bin/.
+          cp /usr/local/opt/libusb-compat/lib/libusb-0.1.4.dylib ./avarice_installed/usr/local/bin/.
+          otool -L avarice_installed/usr/local/bin/avarice
+      - name: Run AVaRICE
+        run: |
+          avarice_installed/usr/local/bin/avarice --version
+          avarice_installed/usr/local/bin/avarice --known-devices || true
+      - name: Tar files
+        run: tar -cvf avarice.tar.gz -C avarice_installed .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: AVaRICE Mac OS Intel 64-bit
           path: avarice.tar.gz

--- a/src/gnu_getopt.c
+++ b/src/gnu_getopt.c
@@ -216,7 +216,7 @@ static char *posixly_correct;
    whose names are inconsistent.  */
 
 #ifndef getenv
-extern char *getenv ();
+extern char *getenv (const char *);
 #endif
 
 static char *


### PR DESCRIPTION
Fixed:
 - getenv declaration fixed in gnu_getopt.c (for Windows)
 - Copied libusb-1.0.dll to msys-usb-1.0.dll (and now you can start avarice under WIndows 11 - and I have no idea why)
 - Changed the path determination for hidapi in the macOS part so that it can deal with different versions
 
Added:
- Generation of Linux ARM binary
- Generation of macOS Intel binary